### PR TITLE
Fix Prisma stuff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2290,7 +2290,6 @@ dependencies = [
  "json-rpc-api-build 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5)",
  "jsonrpc-core",
  "migration-connector 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5)",
- "mongodb-migration-connector 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5)",
  "psl 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5)",
  "serde",
  "serde_json",
@@ -2314,7 +2313,7 @@ dependencies = [
  "json-rpc-api-build 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?rev=fc595772f32ec7c1896da5545b8b87afbbdb7fc3)",
  "jsonrpc-core",
  "migration-connector 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?rev=fc595772f32ec7c1896da5545b8b87afbbdb7fc3)",
- "mongodb-migration-connector 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?rev=fc595772f32ec7c1896da5545b8b87afbbdb7fc3)",
+ "mongodb-migration-connector",
  "psl 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?rev=fc595772f32ec7c1896da5545b8b87afbbdb7fc3)",
  "serde",
  "serde_json",
@@ -2427,46 +2426,12 @@ dependencies = [
 [[package]]
 name = "mongodb-client"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
-dependencies = [
- "mongodb",
- "once_cell",
- "percent-encoding",
- "thiserror",
-]
-
-[[package]]
-name = "mongodb-client"
-version = "0.1.0"
 source = "git+https://github.com/Brendonovich/prisma-engines?rev=fc595772f32ec7c1896da5545b8b87afbbdb7fc3#fc595772f32ec7c1896da5545b8b87afbbdb7fc3"
 dependencies = [
  "mongodb",
  "once_cell",
  "percent-encoding",
  "thiserror",
-]
-
-[[package]]
-name = "mongodb-introspection-connector"
-version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
-dependencies = [
- "async-trait",
- "convert_case 0.5.0",
- "datamodel-renderer 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5)",
- "enumflags2",
- "futures",
- "indoc",
- "introspection-connector 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5)",
- "mongodb",
- "mongodb-client 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5)",
- "mongodb-schema-describer 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5)",
- "once_cell",
- "psl 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5)",
- "regex",
- "serde_json",
- "thiserror",
- "user-facing-errors 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5)",
 ]
 
 [[package]]
@@ -2482,8 +2447,8 @@ dependencies = [
  "indoc",
  "introspection-connector 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?rev=fc595772f32ec7c1896da5545b8b87afbbdb7fc3)",
  "mongodb",
- "mongodb-client 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?rev=fc595772f32ec7c1896da5545b8b87afbbdb7fc3)",
- "mongodb-schema-describer 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?rev=fc595772f32ec7c1896da5545b8b87afbbdb7fc3)",
+ "mongodb-client",
+ "mongodb-schema-describer",
  "once_cell",
  "psl 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?rev=fc595772f32ec7c1896da5545b8b87afbbdb7fc3)",
  "regex",
@@ -2495,33 +2460,15 @@ dependencies = [
 [[package]]
 name = "mongodb-migration-connector"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
-dependencies = [
- "enumflags2",
- "futures",
- "migration-connector 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5)",
- "mongodb",
- "mongodb-client 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5)",
- "mongodb-introspection-connector 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5)",
- "mongodb-schema-describer 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5)",
- "psl 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5)",
- "serde_json",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "mongodb-migration-connector"
-version = "0.1.0"
 source = "git+https://github.com/Brendonovich/prisma-engines?rev=fc595772f32ec7c1896da5545b8b87afbbdb7fc3#fc595772f32ec7c1896da5545b8b87afbbdb7fc3"
 dependencies = [
  "enumflags2",
  "futures",
  "migration-connector 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?rev=fc595772f32ec7c1896da5545b8b87afbbdb7fc3)",
  "mongodb",
- "mongodb-client 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?rev=fc595772f32ec7c1896da5545b8b87afbbdb7fc3)",
- "mongodb-introspection-connector 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?rev=fc595772f32ec7c1896da5545b8b87afbbdb7fc3)",
- "mongodb-schema-describer 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?rev=fc595772f32ec7c1896da5545b8b87afbbdb7fc3)",
+ "mongodb-client",
+ "mongodb-introspection-connector",
+ "mongodb-schema-describer",
  "psl 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?rev=fc595772f32ec7c1896da5545b8b87afbbdb7fc3)",
  "serde_json",
  "tokio",
@@ -2531,39 +2478,6 @@ dependencies = [
 [[package]]
 name = "mongodb-query-connector"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
-dependencies = [
- "anyhow",
- "async-trait",
- "bigdecimal",
- "bson",
- "chrono",
- "cuid",
- "futures",
- "indexmap",
- "itertools",
- "mongodb",
- "mongodb-client 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5)",
- "prisma-models 0.0.0 (git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5)",
- "prisma-value 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5)",
- "psl 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5)",
- "query-connector 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5)",
- "query-engine-metrics 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5)",
- "rand 0.7.3",
- "regex",
- "serde",
- "serde_json",
- "thiserror",
- "tokio",
- "tracing",
- "tracing-futures",
- "user-facing-errors 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5)",
- "uuid 1.3.0",
-]
-
-[[package]]
-name = "mongodb-query-connector"
-version = "0.1.0"
 source = "git+https://github.com/Brendonovich/prisma-engines?rev=fc595772f32ec7c1896da5545b8b87afbbdb7fc3#fc595772f32ec7c1896da5545b8b87afbbdb7fc3"
 dependencies = [
  "anyhow",
@@ -2576,7 +2490,7 @@ dependencies = [
  "indexmap",
  "itertools",
  "mongodb",
- "mongodb-client 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?rev=fc595772f32ec7c1896da5545b8b87afbbdb7fc3)",
+ "mongodb-client",
  "prisma-models 0.0.0 (git+https://github.com/Brendonovich/prisma-engines?rev=fc595772f32ec7c1896da5545b8b87afbbdb7fc3)",
  "prisma-value 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?rev=fc595772f32ec7c1896da5545b8b87afbbdb7fc3)",
  "psl 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?rev=fc595772f32ec7c1896da5545b8b87afbbdb7fc3)",
@@ -2592,16 +2506,6 @@ dependencies = [
  "tracing-futures",
  "user-facing-errors 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?rev=fc595772f32ec7c1896da5545b8b87afbbdb7fc3)",
  "uuid 1.3.0",
-]
-
-[[package]]
-name = "mongodb-schema-describer"
-version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
-dependencies = [
- "futures",
- "mongodb",
- "serde",
 ]
 
 [[package]]
@@ -3234,7 +3138,6 @@ checksum = "c6fa0831dd7cc608c38a5e323422a0077678fa5744aa2be4ad91c4ece8eec8d5"
 name = "prisma-cli"
 version = "0.1.0"
 dependencies = [
- "prisma-client-rust 0.6.5",
  "prisma-client-rust-cli",
 ]
 
@@ -3299,8 +3202,8 @@ dependencies = [
 
 [[package]]
 name = "prisma-client-rust-cli"
-version = "0.6.5"
-source = "git+https://github.com/Brendonovich/prisma-client-rust?branch=main#1569ca466d610e128f057ee3446f2b56c6f9a14d"
+version = "0.6.6"
+source = "git+https://github.com/Brendonovich/prisma-client-rust?rev=1699cff77f47acbee5d8adf3684d64a15e964ae7#1699cff77f47acbee5d8adf3684d64a15e964ae7"
 dependencies = [
  "directories",
  "flate2",
@@ -3319,16 +3222,16 @@ dependencies = [
 
 [[package]]
 name = "prisma-client-rust-sdk"
-version = "0.6.5"
-source = "git+https://github.com/Brendonovich/prisma-client-rust?branch=main#1569ca466d610e128f057ee3446f2b56c6f9a14d"
+version = "0.6.6"
+source = "git+https://github.com/Brendonovich/prisma-client-rust?rev=1699cff77f47acbee5d8adf3684d64a15e964ae7#1699cff77f47acbee5d8adf3684d64a15e964ae7"
 dependencies = [
  "convert_case 0.5.0",
- "dml 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?rev=fc595772f32ec7c1896da5545b8b87afbbdb7fc3)",
- "dmmf 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?rev=fc595772f32ec7c1896da5545b8b87afbbdb7fc3)",
- "prisma-models 0.0.0 (git+https://github.com/Brendonovich/prisma-engines?rev=fc595772f32ec7c1896da5545b8b87afbbdb7fc3)",
+ "dml 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5)",
+ "dmmf 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5)",
+ "prisma-models 0.0.0 (git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5)",
  "proc-macro2",
- "psl 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?rev=fc595772f32ec7c1896da5545b8b87afbbdb7fc3)",
- "query-core 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?rev=fc595772f32ec7c1896da5545b8b87afbbdb7fc3)",
+ "psl 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5)",
+ "query-core 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5)",
  "quote",
  "request-handlers",
  "serde",
@@ -3542,27 +3445,21 @@ dependencies = [
  "bytes",
  "chrono",
  "connection-string",
- "either",
  "futures",
  "hex",
- "libsqlite3-sys",
  "lru-cache",
  "metrics 0.18.1",
  "mobc",
- "mysql_async",
  "native-tls",
  "num_cpus",
  "percent-encoding",
  "postgres-native-tls",
  "postgres-types",
- "rusqlite",
  "serde_json",
  "sqlformat",
  "thiserror",
- "tiberius",
  "tokio",
  "tokio-postgres",
- "tokio-util 0.6.10",
  "tracing",
  "tracing-core",
  "url",
@@ -3683,8 +3580,6 @@ dependencies = [
  "itertools",
  "lazy_static",
  "lru",
- "mongodb-client 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5)",
- "mongodb-query-connector 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5)",
  "once_cell",
  "opentelemetry",
  "parking_lot 0.12.1",
@@ -3729,8 +3624,8 @@ dependencies = [
  "itertools",
  "lazy_static",
  "lru",
- "mongodb-client 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?rev=fc595772f32ec7c1896da5545b8b87afbbdb7fc3)",
- "mongodb-query-connector 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?rev=fc595772f32ec7c1896da5545b8b87afbbdb7fc3)",
+ "mongodb-client",
+ "mongodb-query-connector",
  "once_cell",
  "opentelemetry",
  "parking_lot 0.12.1",
@@ -3966,23 +3861,23 @@ dependencies = [
 [[package]]
 name = "request-handlers"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?rev=fc595772f32ec7c1896da5545b8b87afbbdb7fc3#fc595772f32ec7c1896da5545b8b87afbbdb7fc3"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
 dependencies = [
  "bigdecimal",
  "connection-string",
- "dmmf 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?rev=fc595772f32ec7c1896da5545b8b87afbbdb7fc3)",
+ "dmmf 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5)",
  "futures",
  "graphql-parser",
  "indexmap",
  "itertools",
- "psl 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?rev=fc595772f32ec7c1896da5545b8b87afbbdb7fc3)",
- "query-core 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?rev=fc595772f32ec7c1896da5545b8b87afbbdb7fc3)",
+ "psl 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5)",
+ "query-core 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5)",
  "serde",
  "serde_json",
  "thiserror",
  "tracing",
  "url",
- "user-facing-errors 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?rev=fc595772f32ec7c1896da5545b8b87afbbdb7fc3)",
+ "user-facing-errors 0.1.0 (git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,12 @@ name = "backend"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[workspace]
+members = ["prisma-cli", "macros", "macros-derive"]
+
+[workspace.dependencies]
+prisma-client-rust = { git = "https://github.com/Brendonovich/prisma-client-rust", rev = "1699cff77f47acbee5d8adf3684d64a15e964ae7", default-features = false, features = ["postgresql"] }
+prisma-client-rust-cli = { git = "https://github.com/Brendonovich/prisma-client-rust", rev = "1699cff77f47acbee5d8adf3684d64a15e964ae7", default-features = false, features = ["postgresql"] }
 
 [dependencies]
 tracing = "*"
@@ -12,7 +17,7 @@ axum = { version = "0.6.11", features = ["macros", "headers"] }
 tower-http = { version = "0.4.0", features=["cors"]}
 tokio = { version = "1.26.0", features = ["macros"] }
 anyhow = "1.0.69"
-prisma-client-rust = { git = "https://github.com/Brendonovich/prisma-client-rust", rev = "1699cff77f47acbee5d8adf3684d64a15e964ae7" }
+prisma-client-rust.workspace = true
 serde = { version = "1.0.156", features = ["derive"] }
 once_cell = "1.17.1"
 thiserror = "1.0.39"
@@ -21,7 +26,3 @@ sha2 = "0.10.6"
 jsonwebtoken = "8.3.0"
 dotenv = "0.15.0"
 async-trait = "0.1.66"
-
-
-[workspace]
-members = ["prisma-cli", "macros", "macros-derive"]

--- a/prisma-cli/Cargo.toml
+++ b/prisma-cli/Cargo.toml
@@ -6,5 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-prisma-client-rust-cli = { git = "https://github.com/Brendonovich/prisma-client-rust", branch = "main" }
-prisma-client-rust = { git = "https://github.com/Brendonovich/prisma-client-rust", branch = "main" }
+prisma-client-rust-cli.workspace = true


### PR DESCRIPTION
I think your issue is that you were using different versions of `prisma-client-rust` and `prisma-client-rust-cli`. I've changed to using workspace dependencies so that these versions can be kept in sync more easily, and also disabled all database connectors except `postgresql` for better compile times.